### PR TITLE
Fix logging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.1
+current_version = 1.0.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("README.md") as infile:
 
 setup(
     name="bcr-api",
-    version="1.0.1",
+    version="1.0.2",
     description="A client library for the Brandwatch Consumer Research API",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/bcr_api/__init__.py
+++ b/src/bcr_api/__init__.py
@@ -1,3 +1,3 @@
 """Top-level package for bcr."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/bcr_api/authenticate.py
+++ b/src/bcr_api/authenticate.py
@@ -23,7 +23,7 @@ def authenticate(username, password, credentials_path=None):
 
 
 def main():
-    logger = logging.getLogger("bcr")
+    logger = logging.getLogger("bcr_api")
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler()
     formatter = logging.Formatter("%(levelname)s: %(message)s", "%H:%M:%S")

--- a/src/bcr_api/bwdata.py
+++ b/src/bcr_api/bwdata.py
@@ -5,7 +5,7 @@ import datetime
 from . import filters
 import logging
 
-logger = logging.getLogger("bcr")
+logger = logging.getLogger("bcr_api")
 
 
 class BWData:

--- a/src/bcr_api/bwproject.py
+++ b/src/bcr_api/bwproject.py
@@ -8,7 +8,7 @@ import logging
 
 from .credentials import CredentialsStore
 
-logger = logging.getLogger("bcr")
+logger = logging.getLogger("bcr_api")
 handler = logging.StreamHandler()
 formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s", "%H:%M:%S")
 handler.setFormatter(formatter)

--- a/src/bcr_api/bwresources.py
+++ b/src/bcr_api/bwresources.py
@@ -8,7 +8,7 @@ from . import bwdata
 import logging
 
 
-logger = logging.getLogger("bcr")
+logger = logging.getLogger("bcr_api")
 
 
 class AmbiguityError(ValueError):

--- a/src/bcr_api/credentials.py
+++ b/src/bcr_api/credentials.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 DEFAULT_CREDENTIALS_PATH = Path(os.path.expanduser("~")) / ".bcr" / "credentials.txt"
 
-logger = logging.getLogger("bcr")
+logger = logging.getLogger("bcr_api")
 
 
 class CredentialsStore:


### PR DESCRIPTION
Changed instances of logging.getLogger("bcr") to logging.getLogger("bcr_api") to be consistent with what DEMO.ipynb says a user should do (it says to get the "bcr_api" logger). This change also makes the user experience better because they can expect the name of the logger to be the same as the library that they are importing