### PR TITLE
Added limit to list of filters

### DIFF
--- a/src/bcr_api/filters.py
+++ b/src/bcr_api/filters.py
@@ -43,6 +43,7 @@ params = {
     "instagramInteractionsMin": int,
     "language": str,
     "xlanguage": str,
+    "limit: int,  # user passes in an int which decides how many authors or sites to retrieve
     "locationGroup": list,  # user passes in a string which gets converted to a list of ids
     "xlocationGroup": list,  # user passes in a string which gets converted to a list of ids
     "location": str,


### PR DESCRIPTION
I added the filter "limit" to filters.py so that users see they can choose how many authors or sites they can retrieve. 