### PR TITLE
default log level and tokens

### DIFF
--- a/DEMO.ipynb
+++ b/DEMO.ipynb
@@ -56,7 +56,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The library uses the Python logging module to tell you what it's doing; if desired you can control what sort of output you see by uncommenting one of the lines below:"
+    "The library uses the Python logging module to tell you what it's doing, with a basic config baked into the API. If desired you can control what sort of output you see by uncommenting one of the lines below.\n",
+    "\n",
+    "The default level has changed from DEBGUG (very verbose) to WARNING. "
    ]
   },
   {
@@ -65,23 +67,37 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import logging\n",
-    "logger = logging.getLogger(\"bcr_api\")\n",
+    "# import logging\n",
+    "# logger = logging.getLogger(\"bcr_api\")\n",
     "\n",
-    "#(Default) All logging messages enabled\n",
-    "#logger.setLevel(logging.DEBUG)\n",
+    "# or if you prefer \n",
+    "# import logging\n",
+    "# from bcr_api.logger import get_logger\n",
+    "# logger = get_logger()\n",
     "\n",
-    "#Does not report URLs of API requests, but all other messages enabled\n",
-    "#logger.setLevel(logging.INFO)\n",
+    "# All logging messages enabled\n",
+    "# logger.setLevel(logging.DEBUG)\n",
     "\n",
-    "#Report only errors and warnings\n",
-    "#logger.setLevel(logging.WARN)\n",
+    "# Does not report URLs of API requests, but all other messages enabled\n",
+    "# logger.setLevel(logging.INFO)\n",
     "\n",
-    "#Report only errors\n",
-    "#logger.setLevel(logging.ERROR)\n",
+    "# Report only errors and warnings - the default level\n",
+    "# logger.setLevel(logging.WARNING)\n",
     "\n",
-    "#Disable logging\n",
-    "#logger.setLevel(logging.CRITICAL)"
+    "# Report only errors\n",
+    "# logger.setLevel(logging.ERROR)\n",
+    "\n",
+    "# Disable logging\n",
+    "# logger.setLevel(logging.CRITICAL)\n",
+    "\n",
+    "# or you might have code which sets up a defaut logging level before touching the API, which works as well\n",
+    "# however, this would need to go _before_ the imports above\n",
+    "# import logging\n",
+    "# logging.basicConfig(\n",
+    "#     format=\"%(asctime)s %(levelname)s: %(message)s\",\n",
+    "#     datefmt=\"%H:%M:%S\",\n",
+    "#     level=logging.DEBUG\n",
+    "# )"
    ]
   },
   {
@@ -95,12 +111,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When you use the API for the first time you have to authenticate with Brandwatch. This will get you an access token. The access token is stored in a credentials file (`tokens.txt` in this example). Once you've authenticated your access token will be read from that file so you won't need to enter your password again (until your token expires).\n",
+    "When you use the API for the first time you have to authenticate with Brandwatch. This will get you an access token. The access token is stored in a credentials file (`~/.bcr/credentials.txt` in this example). Once you've authenticated your access token will be read from that file so you won't need to enter your password again (until your token expires).\n",
     "\n",
     "You can authenticate from command line using the provided console script `bcr-authenticate`:\n",
     "\n",
     "```\n",
-    "$ bcr-authenticate\n",
+    "$ pipenv run bcr-authenticate\n",
     "Please enter your Brandwatch credentials below\n",
     "Username: example@example\n",
     "Password:\n",
@@ -109,6 +125,8 @@
     "Writing access token for user: example@example\n",
     "Success! Access token: 00000000-0000-0000-0000-000000000000\n",
     "```\n",
+    "\n",
+    "`bcr-authenticate --store tokens.txt` puts the tokens file back into the current project rather than the shared `~/.bcr/credentials.txt` file.\n",
     "\n",
     "Alternatively, you can authenticate directly:"
    ]
@@ -1366,7 +1384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/src/bcr_api/authenticate.py
+++ b/src/bcr_api/authenticate.py
@@ -1,7 +1,6 @@
 # coding=utf-8
 
 from getpass import getpass
-import logging
 from pathlib import Path
 
 from . import credentials
@@ -23,13 +22,6 @@ def authenticate(username, password, credentials_path=None):
 
 
 def main():
-    logger = logging.getLogger("bcr_api")
-    logger.setLevel(logging.INFO)
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter("%(levelname)s: %(message)s", "%H:%M:%S")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
     parser = argparse.ArgumentParser(
         description="Logging to Brandwatch and retrieve and access token.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/src/bcr_api/authenticate.py
+++ b/src/bcr_api/authenticate.py
@@ -4,7 +4,6 @@ from getpass import getpass
 from pathlib import Path
 
 from bcr_api.config import DEFAULT_CREDENTIALS_PATH
-from . import credentials
 from .bwproject import BWUser
 
 import argparse

--- a/src/bcr_api/authenticate.py
+++ b/src/bcr_api/authenticate.py
@@ -3,6 +3,7 @@
 from getpass import getpass
 from pathlib import Path
 
+from bcr_api.config import DEFAULT_CREDENTIALS_PATH
 from . import credentials
 from .bwproject import BWUser
 
@@ -32,7 +33,7 @@ def main():
         "-s",
         type=Path,
         metavar="PATH",
-        default=credentials.DEFAULT_CREDENTIALS_PATH,
+        default=DEFAULT_CREDENTIALS_PATH,
         help="Path to where access tokens are stored.",
     )
 

--- a/src/bcr_api/bwdata.py
+++ b/src/bcr_api/bwdata.py
@@ -3,9 +3,10 @@ bwdata contains the BWData class.
 """
 import datetime
 from . import filters
-import logging
+from .logger import get_logger
 
-logger = logging.getLogger("bcr_api")
+
+logger = get_logger()
 
 
 class BWData:

--- a/src/bcr_api/bwproject.py
+++ b/src/bcr_api/bwproject.py
@@ -6,6 +6,7 @@ import requests
 import time
 import json
 
+from .config import DEFAULT_CREDENTIALS_PATH
 from .credentials import CredentialsStore
 from .logger import get_logger
 
@@ -29,7 +30,7 @@ class BWUser:
     def __init__(
         self,
         token=None,
-        token_path="tokens.txt",
+        token_path=DEFAULT_CREDENTIALS_PATH,
         username=None,
         password=None,
         grant_type="api-password",
@@ -44,7 +45,8 @@ class BWUser:
             username:   Brandwatch username.
             password:   Brandwatch password - Optional if you already have an access token.
             token:      Access token - Optional.
-            token_path:  File path to the file where access tokens will be read from and written to - Optional.  Defaults to tokens.txt, pass None to disable.
+            token_path:  File path to the file where access tokens will be read from and written to.
+                        Optional.  Defaults to DEFAULT_CREDENTIALS_PATH, pass None to disable.
         """
         self.apiurl = apiurl
         self.oauthpath = "oauth/token"
@@ -253,7 +255,7 @@ class BWProject(BWUser):
         self,
         project,
         token=None,
-        token_path="tokens.txt",
+        token_path=DEFAULT_CREDENTIALS_PATH,
         username=None,
         password=None,
         grant_type="api-password",

--- a/src/bcr_api/bwproject.py
+++ b/src/bcr_api/bwproject.py
@@ -4,17 +4,13 @@ bwproject contains the BWUser and BWProject classes
 
 import requests
 import time
-import logging
 import json
 
 from .credentials import CredentialsStore
+from .logger import get_logger
 
-logger = logging.getLogger("bcr_api")
-handler = logging.StreamHandler()
-formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s", "%H:%M:%S")
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-logger.setLevel(logging.DEBUG)
+
+logger = get_logger()
 
 
 class BWUser:

--- a/src/bcr_api/bwresources.py
+++ b/src/bcr_api/bwresources.py
@@ -5,10 +5,10 @@ bwresources contains the BWMentions, BWQueries, BWGroups, BWRules, BWTags, BWCat
 import json
 from . import filters
 from . import bwdata
-import logging
+from .logger import get_logger
 
 
-logger = logging.getLogger("bcr_api")
+logger = get_logger()
 
 
 class AmbiguityError(ValueError):

--- a/src/bcr_api/config.py
+++ b/src/bcr_api/config.py
@@ -1,0 +1,5 @@
+import os
+from pathlib import Path
+
+
+DEFAULT_CREDENTIALS_PATH = Path(os.path.expanduser("~")) / ".bcr" / "credentials.txt"

--- a/src/bcr_api/credentials.py
+++ b/src/bcr_api/credentials.py
@@ -33,6 +33,11 @@ class CredentialsStore:
     def __getitem__(self, username):
         """Get self[username]"""
         user_tokens = self._read()
+        username = username.lower()
+        if username not in user_tokens:
+            raise KeyError(
+                f"{username} not present in credentials {self._credentials_path}"
+            )
         return user_tokens[username.lower()]
 
     def __setitem__(self, username, token):

--- a/src/bcr_api/credentials.py
+++ b/src/bcr_api/credentials.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from bcr_api.logger import get_logger
 
 
-DEFAULT_CREDENTIALS_PATH = Path(os.path.expanduser("~")) / ".bcr" / "credentials.txt"
 
 
 logger = get_logger()

--- a/src/bcr_api/credentials.py
+++ b/src/bcr_api/credentials.py
@@ -3,12 +3,10 @@
 credentials contains the CredentialsStore class, which responsible for persisting access tokens to disk.
 """
 
-import os
 from pathlib import Path
 
-from bcr_api.logger import get_logger
-
-
+from .config import DEFAULT_CREDENTIALS_PATH
+from .logger import get_logger
 
 
 logger = get_logger()

--- a/src/bcr_api/credentials.py
+++ b/src/bcr_api/credentials.py
@@ -3,13 +3,16 @@
 credentials contains the CredentialsStore class, which responsible for persisting access tokens to disk.
 """
 
-import logging
 import os
 from pathlib import Path
 
+from bcr_api.logger import get_logger
+
+
 DEFAULT_CREDENTIALS_PATH = Path(os.path.expanduser("~")) / ".bcr" / "credentials.txt"
 
-logger = logging.getLogger("bcr_api")
+
+logger = get_logger()
 
 
 class CredentialsStore:

--- a/src/bcr_api/logger.py
+++ b/src/bcr_api/logger.py
@@ -2,10 +2,10 @@ import logging
 
 
 def get_logger():
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+        level=logging.DEBUG,
+    )
     logger = logging.getLogger("bcr_api")
-    logger.setLevel(logging.INFO)
-    handler = logging.StreamHandler()
-    formatter = logging.Formatter("%(levelname)s: %(message)s", "%H:%M:%S")
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
     return logger

--- a/src/bcr_api/logger.py
+++ b/src/bcr_api/logger.py
@@ -1,11 +1,11 @@
 import logging
 
 
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+
 def get_logger():
-    logging.basicConfig(
-        format="%(asctime)s %(levelname)s: %(message)s",
-        datefmt="%H:%M:%S",
-        level=logging.DEBUG,
-    )
-    logger = logging.getLogger("bcr_api")
-    return logger
+    return logging.getLogger("bcr_api")

--- a/src/bcr_api/logger.py
+++ b/src/bcr_api/logger.py
@@ -1,0 +1,11 @@
+import logging
+
+
+def get_logger():
+    logger = logging.getLogger("bcr_api")
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(levelname)s: %(message)s", "%H:%M:%S")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger


### PR DESCRIPTION
The logging within the api code should not fix the logging config in a way that is hard to overwrite, for code which will import it. As discussed in https://github.com/BrandwatchLtd/bcr-api/issues/35

This PR does a couple of logging related things things:
  1. It extracts the logging config out to one place in the API code.
  2. It reduces that config so that it is easier to overwrite in any importing code.
  3. It updates the DEMO notebook, with a couple of alternative ways of changing the logging, and noting that the default has changed.

The log level can still be changed but is not overridden by this code.

The default log level is now WARNING. This makes the default much less verbose. It can easily be changed, as was already documented. **Will this change confuse users?**

In testing and tweaking the demo I also hit an issue with the token storage in a fresh clone of the API:
 - `bcr-authenticate` had a default tokens file of `~/.bcr/credentials.txt`
 - `BWProject` and `BWUser` had a default location of `./tokens.txt`
 - The notebook moves from `bcr-authenticate` to providing `tokens.txt` in example calls, when that file was non-existent or empty and so led to errors.
 
I've made `BWProject` and `BWUser` share the same default as `bcr-authenticate`. 
If code has been written assuming `tokens.txt` rather than explicitly providing it this will break.
The DEMO notebook has been updated to comment on this, but **for existing code this may be a breaking change**.

It would be easy to make `tokens.txt` the default, but I assume that a central location was introduced for a reason.