### PR TITLE
Language bug fix

### DIFF
--- a/src/bcr_api/bwproject.py
+++ b/src/bcr_api/bwproject.py
@@ -126,15 +126,15 @@ class BWUser:
 
         Keyword Args:
             booleanQuery: Search terms included in the query.
-            language: List of the languages in which you'd like to test the query - Optional.
+            languages: List of the languages in which you'd like to test the query - Optional.
 
         Raises:
             KeyError: If you don't pass a search or if the search has errors in it.
         """
         if "booleanQuery" not in kwargs:
             raise KeyError("Must pass: booleanQuery = 'search terms'")
-        if "language" not in kwargs:
-            kwargs["language"] = ["en"]
+        if "languages" not in kwargs:
+            kwargs["languages"] = ["en"]
 
         valid_search = self.request(
             verb=requests.post, address="query-validation", data=json.dumps(kwargs)
@@ -147,15 +147,15 @@ class BWUser:
 
         Keyword Args:
             booleanQuery: Search terms included in the rule.
-            language: List of the languages in which you'd like to test the query - Optional.
+            languages: List of the languages in which you'd like to test the query - Optional.
 
         Raises:
             KeyError: If you don't pass a search or if the search has errors in it.
         """
         if "booleanQuery" not in kwargs:
             raise KeyError("Must pass: booleanQuery = 'search terms'")
-        if "language" not in kwargs:
-            kwargs["language"] = ["en"]
+        if "languages" not in kwargs:
+            kwargs["languages"] = ["en"]
 
         valid_search = self.request(
             verb=requests.get, address="query-validation/searchwithin", params=kwargs

--- a/src/bcr_api/bwresources.py
+++ b/src/bcr_api/bwresources.py
@@ -245,7 +245,7 @@ class BWResource:
         # validating the query search
         if "search" in filled["filter"]:
             self.project.validate_rule_search(
-                booleanQuery=filled["filter"]["search"], language="en"
+                booleanQuery=filled["filter"]["search"], languages="en"
             )
         return filled
 
@@ -505,7 +505,7 @@ class BWQueries(BWResource, bwdata.BWData):
 
         # validating the query search - comment this out to skip validation
         self.project.validate_query_search(
-            booleanQuery=filled["booleanQuery"], language=["en"]
+            booleanQuery=filled["booleanQuery"], languages=["en"]
         )
         return json.dumps(filled)
 
@@ -1259,7 +1259,7 @@ class BWCategories:
         # validating the rule search
         if "search" in filled["filter"]:
             self.project.validate_rule_search(
-                booleanQuery=filled["filter"]["search"], language="en"
+                booleanQuery=filled["filter"]["search"], languages="en"
             )
         return filled
 
@@ -1626,7 +1626,7 @@ class BWRules(BWResource):
         # validating the query search
         if "search" in filled["filter"]:
             self.project.validate_rule_search(
-                booleanQuery=filled["filter"]["search"], language="en"
+                booleanQuery=filled["filter"]["search"], languages="en"
             )
 
         if "scope" in data:


### PR DESCRIPTION
Fresh pull from [bcr-api](https://github.com/BrandwatchLtd/bcr-api) results in a known [language issue](https://github.com/BrandwatchLtd/bcr-api/issues/38), where users cannot create new queries.

This was seemingly caused by a typo - "language" instead of "languages" in the **kwargs.

Queries can now be created under this fix, and languages can be specified.